### PR TITLE
feat: raw identifier syntax

### DIFF
--- a/mlx/lexer.mll
+++ b/mlx/lexer.mll
@@ -355,6 +355,7 @@ let kwdopchar =
 
 let ident = (lowercase | uppercase) identchar*
 let extattrident = ident ('.' ident)*
+let raw_ident_escape = "\\#"
 
 let decimal_literal =
   ['0'-'9'] ['0'-'9' '_']*
@@ -396,6 +397,8 @@ rule token = parse
   | ".~"
       { error lexbuf
           (Reserved_sequence (".~", Some "is reserved for use in MetaOCaml")) }
+  | "~" raw_ident_escape (lowercase identchar * as name) ':'
+      { LABEL name }
   | "~" (lowercase identchar * as name) ':'
       { check_label_name lexbuf name;
         LABEL name }
@@ -404,17 +407,23 @@ rule token = parse
         LABEL name }
   | "?"
       { QUESTION }
+  | "?" raw_ident_escape (lowercase identchar * as name) ':'
+      { OPTLABEL name }
   | "?" (lowercase identchar * as name) ':'
       { check_label_name lexbuf name;
         OPTLABEL name }
   | "?" (lowercase_latin1 identchar_latin1 * as name) ':'
       { warn_latin1 lexbuf;
         OPTLABEL name }
+  | raw_ident_escape (lowercase identchar * as name)
+      { LIDENT name }
   | lowercase identchar * as name
       { try Hashtbl.find keyword_table name
         with Not_found -> LIDENT name }
   | lowercase_latin1 identchar_latin1 * as name
       { warn_latin1 lexbuf; LIDENT name }
+  | "<" raw_ident_escape (lowercase identchar * as name)
+      { JSX_LIDENT name }
   | "<" (lowercase identchar * as name)
       { JSX_LIDENT name }
   | "<" "/" (lowercase identchar * as name)

--- a/ocamlmerlin_mlx/ocaml/preprocess/lexer_raw.mll
+++ b/ocamlmerlin_mlx/ocaml/preprocess/lexer_raw.mll
@@ -369,6 +369,7 @@ let kwdopchar =
 
 let ident = (lowercase | uppercase) identchar*
 let extattrident = ident ('.' ident)*
+let raw_ident_escape = "\\#"
 
 let decimal_literal =
   ['0'-'9'] ['0'-'9' '_']*
@@ -426,6 +427,8 @@ rule token state = parse
       { fail lexbuf
           (Reserved_sequence (".~", Some "is reserved for use in MetaOCaml")) }
       *)
+  | "~" raw_ident_escape (lowercase identchar * as name) ':'
+      { return (LABEL name) }
   | "~" (lowercase identchar * as name) ':'
       { lABEL (check_label_name lexbuf name) }
   | "~" (lowercase_latin1 identchar_latin1 * as name) ':'
@@ -433,10 +436,14 @@ rule token state = parse
         return (LABEL name) }
   | "?"
       { return QUESTION }
+  | "?" raw_ident_escape (lowercase identchar * as name) ':'
+      { return (OPTLABEL name) }
   | "?" (lowercase identchar * as name) ':'
       { oPTLABEL (check_label_name lexbuf name) }
   | "?" (lowercase_latin1 identchar_latin1 * as name) ':'
       { warn_latin1 lexbuf; return (OPTLABEL name) }
+  | raw_ident_escape (lowercase identchar * as name)
+      { return (LIDENT name) }
   | lowercase identchar * as name
     { return (try Hashtbl.find state.keywords name
               with Not_found ->
@@ -445,6 +452,8 @@ rule token state = parse
                 LIDENT name) }
   | lowercase_latin1 identchar_latin1 * as name
       { warn_latin1 lexbuf; return (LIDENT name) }
+  | "<" raw_ident_escape (lowercase identchar * as name)
+      { return (JSX_LIDENT name) }
   | "<" (lowercase identchar * as name)
       { return (JSX_LIDENT name) }
   | "<" "/" (lowercase identchar * as name)

--- a/test/mlx.t
+++ b/test/mlx.t
@@ -140,3 +140,73 @@ We have a lexer hack to parse [<element and [<Element as JSX:
   let _ = [ (M.element () ~children:[ 1 ] [@JSX]) ]
   MERLIN
   let _ = [ (M.element () ~children:[ 1 ] [@JSX]) ]
+
+Raw identifiers (\#foo) bypass the keyword table.
+Non-keyword raw identifiers round-trip through the full pipeline:
+
+  $ echo 'let _ = \#foo' | ./mlx
+  BATCH
+  let _ = foo
+  MERLIN
+  let _ = foo
+  $ echo 'let _ = \#bar' | ./mlx
+  BATCH
+  let _ = bar
+  MERLIN
+  let _ = bar
+
+Keyword raw identifiers are verified via tokenization (the OCaml printer
+does not emit \# escapes, so the text round-trip breaks for keywords):
+
+  $ echo 'let x = `\#lazy' | mlx-pp -print-tokens /dev/stdin
+  let
+  x
+  =
+  `
+  \#lazy
+  $ echo 'let x = `\#true' | mlx-pp -print-tokens /dev/stdin
+  let
+  x
+  =
+  `
+  \#true
+  $ echo 'let x = `\#false' | mlx-pp -print-tokens /dev/stdin
+  let
+  x
+  =
+  `
+  \#false
+  $ echo 'let f ~\#true:x = x' | mlx-pp -print-tokens /dev/stdin
+  let
+  f
+  ~\#true:
+  x
+  =
+  x
+  $ echo 'let f ?\#true:(x = true) = x' | mlx-pp -print-tokens /dev/stdin
+  let
+  f
+  ?\#true:
+  (
+  x
+  =
+  true
+  )
+  =
+  x
+  $ echo 'let _ = <\#lazy />' | mlx-pp -print-tokens /dev/stdin
+  let
+  _
+  =
+  <\#lazy
+  />
+  $ echo 'let _ = <element loading=`\#lazy />' | mlx-pp -print-tokens /dev/stdin
+  let
+  _
+  =
+  <element
+  loading
+  =
+  `
+  \#lazy
+  />

--- a/test/mlx.t
+++ b/test/mlx.t
@@ -158,32 +158,32 @@ Non-keyword raw identifiers round-trip through the full pipeline:
 Keyword raw identifiers are verified via tokenization (the OCaml printer
 does not emit \# escapes, so the text round-trip breaks for keywords):
 
-  $ echo 'let x = `\#lazy' | mlx-pp -print-tokens /dev/stdin
+  $ echo 'let x = `\#lazy' | mlx-pp -print-tokens
   let
   x
   =
   `
   \#lazy
-  $ echo 'let x = `\#true' | mlx-pp -print-tokens /dev/stdin
+  $ echo 'let x = `\#true' | mlx-pp -print-tokens
   let
   x
   =
   `
   \#true
-  $ echo 'let x = `\#false' | mlx-pp -print-tokens /dev/stdin
+  $ echo 'let x = `\#false' | mlx-pp -print-tokens
   let
   x
   =
   `
   \#false
-  $ echo 'let f ~\#true:x = x' | mlx-pp -print-tokens /dev/stdin
+  $ echo 'let f ~\#true:x = x' | mlx-pp -print-tokens
   let
   f
   ~\#true:
   x
   =
   x
-  $ echo 'let f ?\#true:(x = true) = x' | mlx-pp -print-tokens /dev/stdin
+  $ echo 'let f ?\#true:(x = true) = x' | mlx-pp -print-tokens
   let
   f
   ?\#true:
@@ -194,13 +194,13 @@ does not emit \# escapes, so the text round-trip breaks for keywords):
   )
   =
   x
-  $ echo 'let _ = <\#lazy />' | mlx-pp -print-tokens /dev/stdin
+  $ echo 'let _ = <\#lazy />' | mlx-pp -print-tokens
   let
   _
   =
   <\#lazy
   />
-  $ echo 'let _ = <element loading=`\#lazy />' | mlx-pp -print-tokens /dev/stdin
+  $ echo 'let _ = <element loading=`\#lazy />' | mlx-pp -print-tokens
   let
   _
   =


### PR DESCRIPTION
Add support for raw identifiers (OCaml 5.2 / RFC 27) to the MLX lexer, allowing keywords to be used as identifiers via the \# prefix.

This unblocks polyvariant tags that collide with OCaml keywords, which is common for HTML attribute values:
```
`\#lazy    (* loading="lazy" *)
`\#true    (* aria-pressed="true" *)
`\#false   (* aria-pressed="false" *)
`\#lazy    (* loading="lazy" *)`\#true    (* aria-pressed="true" *)`\#false   (* aria-pressed="false" *)
```

The implementation mirrors the OCaml compiler's lexer: a `raw_ident_escape` is matched before the regular identifier rules, emitting `LIDENT` directly without keyword-table lookup. Applied to `LABEL`, `OPTLABEL`, `LIDENT`, and `JSX_LIDENT` rules across mlx/lexer.mll and ocamlmerlin_mlx/ocaml/preprocess/lexer_raw.mll.

It also allows `<#lazy>` as a component name